### PR TITLE
Add top command for top artists and tracks

### DIFF
--- a/src/cli/commands/TopCommand.cs
+++ b/src/cli/commands/TopCommand.cs
@@ -1,0 +1,80 @@
+using cli.options;
+using core.services;
+using SpotifyAPI.Web;
+
+namespace cli.commands;
+
+public static class TopCommand
+{
+
+    #region Public Methods
+
+    public static async Task<int> Execute(TopOptions options, ISpotifyService spotifyService)
+    {
+        if (options.Limit is < 1 or > 50)
+        {
+            Console.WriteLine("Limit must be between 1 and 50.");
+            return 1;
+        }
+
+        var timeRange = options.Range switch
+        {
+            "short" => PersonalizationTopRequest.TimeRange.ShortTerm,
+            "long" => PersonalizationTopRequest.TimeRange.LongTerm,
+            _ => PersonalizationTopRequest.TimeRange.MediumTerm
+        };
+
+        spotifyService.EnsureUserLoggedIn(out var spotify);
+
+        bool showBoth = !options.Artists && !options.Tracks;
+
+        if (options.Artists || showBoth)
+        {
+            await PrintTopArtists(spotify, options.Limit, timeRange);
+        }
+
+        if (options.Tracks || showBoth)
+        {
+            await PrintTopTracks(spotify, options.Limit, timeRange);
+        }
+
+        return 0;
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private static async Task PrintTopArtists(SpotifyClient spotify, int limit, PersonalizationTopRequest.TimeRange timeRange)
+    {
+        var request = new PersonalizationTopRequest { Limit = limit, TimeRangeParam = timeRange };
+        var result = await spotify.Personalization.GetTopArtists(request);
+
+        Console.WriteLine("Top Artists:");
+        int rank = 1;
+        foreach (var artist in result.Items ?? [])
+        {
+            var genres = artist.Genres.Count > 0 ? $" [{string.Join(", ", artist.Genres.Take(2))}]" : "";
+            Console.WriteLine($"  {rank++,2}. {artist.Name}{genres}");
+        }
+        Console.WriteLine();
+    }
+
+    private static async Task PrintTopTracks(SpotifyClient spotify, int limit, PersonalizationTopRequest.TimeRange timeRange)
+    {
+        var request = new PersonalizationTopRequest { Limit = limit, TimeRangeParam = timeRange };
+        var result = await spotify.Personalization.GetTopTracks(request);
+
+        Console.WriteLine("Top Tracks:");
+        int rank = 1;
+        foreach (var track in result.Items ?? [])
+        {
+            var artists = string.Join(", ", track.Artists.Select(a => a.Name));
+            Console.WriteLine($"  {rank++,2}. {track.Name} - {artists}");
+        }
+        Console.WriteLine();
+    }
+
+    #endregion
+
+}

--- a/src/cli/options/TopOptions.cs
+++ b/src/cli/options/TopOptions.cs
@@ -1,0 +1,21 @@
+using CommandLine;
+
+namespace cli.options;
+
+[Verb("top", HelpText = "Gets your top artists and tracks from Spotify.")]
+public class TopOptions
+{
+
+    [Option('a', "artists", HelpText = "Show top artists.")]
+    public bool Artists { get; set; }
+
+    [Option('t', "tracks", HelpText = "Show top tracks.")]
+    public bool Tracks { get; set; }
+
+    [Option('l', "limit", Default = 10, HelpText = "Number of results to return (max 50).")]
+    public int Limit { get; set; }
+
+    [Option('r', "range", Default = "medium", HelpText = "Time range: short (4 weeks), medium (6 months), long (all time).")]
+    public string Range { get; set; }
+
+}

--- a/src/main/App.cs
+++ b/src/main/App.cs
@@ -37,6 +37,7 @@ public class App
                 LoginOptions,
                 LogoutOptions,
                 PlaylistsOptions,
+                TopOptions,
                 TracksOptions>(args)
             .MapResult(
                 async (ConfigOptions opts) => await ConfigCommand.Execute(opts, _config),
@@ -44,6 +45,7 @@ public class App
                 async (LoginOptions opts) => await LoginCommand.Execute(opts, _config, _loginService),
                 async (LogoutOptions _) => await LogoutCommand.Execute(_config),
                 async (PlaylistsOptions opts) => await PlaylistsCommand.Execute(opts, _spotifyService),
+                async (TopOptions opts) => await TopCommand.Execute(opts, _spotifyService),
                 async (TracksOptions opts) => await TracksCommand.Execute(opts, _spotifyService),
                 errs => Task.FromResult(1));
     }


### PR DESCRIPTION
## Summary

- Adds a new `top` CLI verb that queries Spotify's Personalization API
- Shows top artists (with genre hints) and top tracks, ranked by listen history
- Supports filtering by `--artists` or `--tracks` (defaults to both)

## Options

| Flag | Description | Default |
|------|-------------|---------|
| `-a` / `--artists` | Show top artists only | — |
| `-t` / `--tracks` | Show top tracks only | — |
| `-l` / `--limit` | Number of results (1–50) | 10 |
| `-r` / `--range` | `short` (4 wks), `medium` (6 mo), `long` (all time) | `medium` |

## Example usage

```
spoticli top
spoticli top --artists --range long
spoticli top --tracks --limit 20 --range short
```

## Test plan

- [x] Run `spoticli top` and verify both artists and tracks are displayed
- [x] Run with `--artists` only and confirm tracks are omitted
- [x] Run with `--tracks` only and confirm artists are omitted
- [ ] Test `--range short` and `--range long` return different results
- [x] Test `--limit 1` and `--limit 50` boundary values
- [x] Verify invalid limit (0 or 51) returns an error

🤖 Generated with [Claude Code](https://claude.com/claude-code)