### PR TITLE
Add daily monitor for changes in top artists and tracks

### DIFF
--- a/scripts/install-monitor.ps1
+++ b/scripts/install-monitor.ps1
@@ -1,0 +1,179 @@
+<#
+.SYNOPSIS
+    Installs the spoticli top-list monitor as a daily Scheduled Task.
+
+.DESCRIPTION
+    Publishes the monitor project as a single self-contained executable, copies it to
+    %LOCALAPPDATA%\Programs\spoticli-monitor, and registers a Scheduled Task named
+    "spoticli Top Monitor" that runs it once a day.
+
+    The task runs interactively as the current user. That matters twice over: the monitor
+    reads your Spotify login from %APPDATA%\spoticli\config.json, and Windows only delivers
+    toast notifications to an interactive session. A Windows Service would satisfy neither.
+
+    Snapshots are stored in %APPDATA%\spoticli\history.db and logs in
+    %APPDATA%\spoticli\logs.
+
+    The script is idempotent. If the task already exists, it offers to reinstall (republish +
+    replace binaries), run it now, or uninstall it.
+
+    Elevation is NOT required - everything is scoped to the current user.
+
+.PARAMETER Time
+    Time of day to run, as HH:mm. Defaults to 00:00 (midnight).
+
+.EXAMPLE
+    .\install-monitor.ps1
+    .\install-monitor.ps1 -Time 03:30
+#>
+[CmdletBinding()]
+param(
+    [ValidatePattern('^\d{2}:\d{2}$')]
+    [string]$Time = '00:00'
+)
+
+$ErrorActionPreference = 'Stop'
+
+$TaskName   = 'spoticli Top Monitor'
+$TaskPath   = '\spoticli\'
+$InstallDir = Join-Path $env:LOCALAPPDATA 'Programs\spoticli-monitor'
+$RepoRoot   = Split-Path -Parent $PSScriptRoot
+$Project    = Join-Path $RepoRoot 'src\monitor\monitor.csproj'
+$StagingDir = Join-Path $RepoRoot 'build\publish\monitor'
+$ExePath    = Join-Path $InstallDir 'sp0-monitor.exe'
+$AumidKey   = 'HKCU:\Software\Classes\AppUserModelId\spoticli.TopMonitor'
+
+function Publish-Monitor {
+    Write-Host "Publishing monitor to staging..." -ForegroundColor Cyan
+    if (Test-Path $StagingDir) {
+        Remove-Item $StagingDir -Recurse -Force
+    }
+    dotnet publish $Project -c Release -o $StagingDir
+    if ($LASTEXITCODE -ne 0) {
+        throw "dotnet publish failed with exit code $LASTEXITCODE"
+    }
+}
+
+function Copy-MonitorFiles {
+    Write-Host "Copying files to $InstallDir..." -ForegroundColor Cyan
+    New-Item -ItemType Directory -Force $InstallDir | Out-Null
+    Copy-Item (Join-Path $StagingDir '*') $InstallDir -Recurse -Force
+}
+
+function Register-MonitorTask {
+    Write-Host "Registering scheduled task '$TaskName' for $Time daily..." -ForegroundColor Cyan
+
+    $action = New-ScheduledTaskAction -Execute $ExePath -WorkingDirectory $InstallDir
+    $trigger = New-ScheduledTaskTrigger -Daily -At $Time
+
+    # Interactive logon so the toast reaches the desktop and %APPDATA% resolves to this user.
+    $principal = New-ScheduledTaskPrincipal -UserId "$env:USERDOMAIN\$env:USERNAME" -LogonType Interactive -RunLevel Limited
+
+    # StartWhenAvailable makes a missed midnight run (machine asleep or logged off) fire once
+    # the user is back, rather than being skipped until tomorrow.
+    $settings = New-ScheduledTaskSettingsSet `
+        -StartWhenAvailable `
+        -AllowStartIfOnBatteries `
+        -DontStopIfGoingOnBatteries `
+        -ExecutionTimeLimit (New-TimeSpan -Minutes 15) `
+        -MultipleInstances IgnoreNew `
+        -Hidden
+
+    Register-ScheduledTask `
+        -TaskName $TaskName `
+        -TaskPath $TaskPath `
+        -Action $action `
+        -Trigger $trigger `
+        -Principal $principal `
+        -Settings $settings `
+        -Description 'Snapshots your top 50 Spotify artists and tracks daily and reports what moved.' `
+        -Force | Out-Null
+
+    Write-Host "Task registered." -ForegroundColor Green
+}
+
+function Unregister-MonitorTask {
+    Write-Host "Removing scheduled task '$TaskName'..." -ForegroundColor Cyan
+    Unregister-ScheduledTask -TaskName $TaskName -TaskPath $TaskPath -Confirm:$false
+    Write-Host "Task removed." -ForegroundColor Green
+
+    if (Test-Path $AumidKey) {
+        Remove-Item $AumidKey -Recurse -Force
+        Write-Host "Removed the toast notification registration." -ForegroundColor Green
+    }
+
+    if (Test-Path $InstallDir) {
+        $answer = Read-Host "Remove installed files at $InstallDir as well? [y/N]"
+        if ($answer -match '^[yY]') {
+            Remove-Item $InstallDir -Recurse -Force
+            Write-Host "Removed $InstallDir." -ForegroundColor Green
+        }
+    }
+
+    $dataDir = Join-Path $env:APPDATA 'spoticli'
+    Write-Host "History and logs were left in $dataDir." -ForegroundColor Yellow
+}
+
+function Start-MonitorTask {
+    Write-Host "Running the monitor now..." -ForegroundColor Cyan
+    Start-ScheduledTask -TaskName $TaskName -TaskPath $TaskPath
+    Write-Host "Started. Check the log at $env:APPDATA\spoticli\logs." -ForegroundColor Green
+}
+
+function Show-Summary {
+    Write-Host ""
+    Write-Host "Installed:  $ExePath"          -ForegroundColor Gray
+    Write-Host "Schedule:   daily at $Time"     -ForegroundColor Gray
+    Write-Host "History:    $env:APPDATA\spoticli\history.db" -ForegroundColor Gray
+    Write-Host "Logs:       $env:APPDATA\spoticli\logs"       -ForegroundColor Gray
+    Write-Host ""
+    Write-Host "Preview a report without touching the history:" -ForegroundColor Gray
+    Write-Host "  & '$ExePath' --dry-run"       -ForegroundColor Gray
+    Write-Host ""
+}
+
+# --- Main ---
+
+$existing = Get-ScheduledTask -TaskName $TaskName -TaskPath $TaskPath -ErrorAction SilentlyContinue
+
+if ($null -eq $existing) {
+    Write-Host "Task '$TaskName' is not installed. Performing fresh install." -ForegroundColor Cyan
+
+    Write-Host ""
+    Write-Host "The monitor reads the Spotify login stored by the CLI. If you have not run" -ForegroundColor Yellow
+    Write-Host "'sp0 login' as this user yet, do that first or the first run will fail." -ForegroundColor Yellow
+    Write-Host ""
+
+    Publish-Monitor
+    Copy-MonitorFiles
+    Register-MonitorTask
+    Show-Summary
+
+    $answer = Read-Host "Run it once now to record the baseline? [Y/n]"
+    if ($answer -notmatch '^[nN]') {
+        Start-MonitorTask
+    }
+}
+else {
+    Write-Host "Task '$TaskName' is already installed (state: $($existing.State))." -ForegroundColor Yellow
+
+    $choices = @(
+        [System.Management.Automation.Host.ChoiceDescription]::new('&Reinstall', 'Republish the monitor, replace the binaries and re-register the task.')
+        [System.Management.Automation.Host.ChoiceDescription]::new('Run &now',   'Trigger the installed task immediately.')
+        [System.Management.Automation.Host.ChoiceDescription]::new('&Uninstall', 'Remove the task and the toast registration.')
+        [System.Management.Automation.Host.ChoiceDescription]::new('&Cancel',    'Do nothing and exit.')
+    )
+    $choice = $Host.UI.PromptForChoice("Task already exists", "What would you like to do?", $choices, 0)
+
+    switch ($choice) {
+        0 {
+            Publish-Monitor
+            Copy-MonitorFiles
+            Register-MonitorTask
+            Show-Summary
+        }
+        1 { Start-MonitorTask }
+        2 { Unregister-MonitorTask }
+        3 { Write-Host "Cancelled." }
+    }
+}

--- a/spoticli.slnx
+++ b/spoticli.slnx
@@ -3,6 +3,7 @@
     <Project Path="src/cli/cli.csproj" />
     <Project Path="src/core/core.csproj" />
     <Project Path="src/main/main.csproj" />
+    <Project Path="src/monitor/monitor.csproj" />
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/core.test/core.test.csproj" />

--- a/src/cli/commands/TopCommand.cs
+++ b/src/cli/commands/TopCommand.cs
@@ -1,4 +1,5 @@
 using cli.options;
+using core.monitor;
 using core.services;
 using SpotifyAPI.Web;
 
@@ -17,12 +18,7 @@ public static class TopCommand
             return 1;
         }
 
-        var timeRange = options.Range switch
-        {
-            "short" => PersonalizationTopRequest.TimeRange.ShortTerm,
-            "long" => PersonalizationTopRequest.TimeRange.LongTerm,
-            _ => PersonalizationTopRequest.TimeRange.MediumTerm
-        };
+        var timeRange = SpotifyTimeRange.Parse(options.Range);
 
         spotifyService.EnsureUserLoggedIn(out var spotify);
 

--- a/src/core/config/ApplicationConfig.cs
+++ b/src/core/config/ApplicationConfig.cs
@@ -32,6 +32,7 @@ public class ApplicationConfig
     #region Properties
 
     public AccountConfig Account { get; } = new AccountConfig();
+    public MonitorConfig Monitor { get; } = new MonitorConfig();
     public SpotifyAppConfig SpotifyApp { get; } = new SpotifyAppConfig();
     public SpotifyTokenConfig SpotifyToken { get; } = new SpotifyTokenConfig();
 

--- a/src/core/config/MonitorConfig.cs
+++ b/src/core/config/MonitorConfig.cs
@@ -1,0 +1,15 @@
+namespace core.config;
+
+public class MonitorConfig
+{
+
+    /// <summary>How many artists and tracks to track per list. Spotify caps this at 50.</summary>
+    public int Limit { get; set; } = 50;
+
+    /// <summary>Which Spotify time ranges to track: "short" (4 weeks), "medium" (6 months), "long" (all time).</summary>
+    public string[] TimeRanges { get; set; } = ["short"];
+
+    /// <summary>Days of history to keep. Zero or less keeps everything.</summary>
+    public int RetentionDays { get; set; } = 365;
+
+}

--- a/src/core/core.csproj
+++ b/src/core/core.csproj
@@ -16,6 +16,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.10" />
+    <!-- Pinned above the version Microsoft.Data.Sqlite pulls in, which carries GHSA-2m69-gcr7-jv3q. -->
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.5" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="SpotifyAPI.Web" Version="7.0.0" />
     <PackageReference Include="SpotifyAPI.Web.Auth" Version="7.0.0" />

--- a/src/core/monitor/ChangeKind.cs
+++ b/src/core/monitor/ChangeKind.cs
@@ -1,0 +1,19 @@
+namespace core.monitor;
+
+public enum ChangeKind
+{
+    /// <summary>Present in both snapshots at the same rank.</summary>
+    Held,
+
+    /// <summary>Present in both snapshots, now ranked higher (a smaller rank number).</summary>
+    MovedUp,
+
+    /// <summary>Present in both snapshots, now ranked lower (a larger rank number).</summary>
+    MovedDown,
+
+    /// <summary>Absent from the previous snapshot.</summary>
+    Entered,
+
+    /// <summary>Absent from the current snapshot.</summary>
+    Left
+}

--- a/src/core/monitor/EntryChange.cs
+++ b/src/core/monitor/EntryChange.cs
@@ -1,0 +1,54 @@
+namespace core.monitor;
+
+/// <summary>
+/// What happened to one artist or track between two snapshots.
+/// </summary>
+public class EntryChange
+{
+
+    #region Properties
+
+    public ChangeKind Kind { get; init; }
+
+    public string SpotifyId { get; init; }
+
+    public string Name { get; init; }
+
+    public string Detail { get; init; }
+
+    /// <summary>Rank in the previous snapshot, or null when the entry is new.</summary>
+    public int? PreviousRank { get; init; }
+
+    /// <summary>Rank in the current snapshot, or null when the entry has dropped out.</summary>
+    public int? CurrentRank { get; init; }
+
+    /// <summary>Places gained. Positive means it moved up the list; zero for entries that came or went.</summary>
+    public int Delta => PreviousRank.HasValue && CurrentRank.HasValue
+        ? PreviousRank.Value - CurrentRank.Value
+        : 0;
+
+    public string Display => string.IsNullOrEmpty(Detail) ? Name : $"{Name} - {Detail}";
+
+    #endregion
+
+    #region Public Methods
+
+    /// <summary>
+    /// A one-line, human-readable description of the change.
+    /// </summary>
+    /// <param name="listSize">Size of the top list, used to phrase entries dropping out.</param>
+    public string Describe(int listSize)
+    {
+        return Kind switch
+        {
+            ChangeKind.Entered => $"{Display} entered at #{CurrentRank}",
+            ChangeKind.Left => $"{Display} is no longer in the top {listSize} (was #{PreviousRank})",
+            ChangeKind.MovedUp => $"{Display} moved up to #{CurrentRank} from #{PreviousRank} (+{Delta})",
+            ChangeKind.MovedDown => $"{Display} moved down to #{CurrentRank} from #{PreviousRank} ({Delta})",
+            _ => $"{Display} held at #{CurrentRank}"
+        };
+    }
+
+    #endregion
+
+}

--- a/src/core/monitor/INotifier.cs
+++ b/src/core/monitor/INotifier.cs
@@ -1,0 +1,12 @@
+namespace core.monitor;
+
+public interface INotifier
+{
+
+    /// <summary>
+    /// Surfaces the outcome of a monitor run to the user. Implementations are expected to swallow
+    /// their own delivery failures rather than take the run down with them.
+    /// </summary>
+    Task NotifyAsync(MonitorRunResult result, CancellationToken cancellationToken = default);
+
+}

--- a/src/core/monitor/ISnapshotStore.cs
+++ b/src/core/monitor/ISnapshotStore.cs
@@ -1,0 +1,18 @@
+namespace core.monitor;
+
+public interface ISnapshotStore
+{
+
+    /// <summary>Creates the database and schema if they are not there yet. Safe to call on every run.</summary>
+    Task InitializeAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>The most recently captured snapshot for a list, or null if none has been recorded.</summary>
+    Task<TopSnapshot> GetLatestAsync(TopEntityType entityType, string timeRange, CancellationToken cancellationToken = default);
+
+    /// <summary>Persists a snapshot and assigns its <see cref="TopSnapshot.Id"/>.</summary>
+    Task SaveAsync(TopSnapshot snapshot, CancellationToken cancellationToken = default);
+
+    /// <summary>Deletes snapshots older than the cutoff. Returns how many were removed.</summary>
+    Task<int> PruneAsync(DateTime olderThanUtc, CancellationToken cancellationToken = default);
+
+}

--- a/src/core/monitor/ITopMonitorService.cs
+++ b/src/core/monitor/ITopMonitorService.cs
@@ -1,0 +1,16 @@
+namespace core.monitor;
+
+public interface ITopMonitorService
+{
+
+    /// <summary>
+    /// Fetches the current top artists and tracks, compares them against the last stored
+    /// snapshots and records the new ones.
+    /// </summary>
+    /// <param name="persist">
+    /// When false the results are still fetched and diffed but nothing is written, which is what
+    /// a dry run uses to preview a report without disturbing the history.
+    /// </param>
+    Task<MonitorRunResult> RunAsync(bool persist = true, CancellationToken cancellationToken = default);
+
+}

--- a/src/core/monitor/MonitorReport.cs
+++ b/src/core/monitor/MonitorReport.cs
@@ -1,0 +1,137 @@
+using System.Text;
+
+namespace core.monitor;
+
+/// <summary>
+/// Turns a run result into text. The full report goes to the log; the short form goes to the toast,
+/// which only has room for a handful of lines.
+/// </summary>
+public static class MonitorReport
+{
+
+    #region Public Methods
+
+    /// <summary>The complete report, one line per change, grouped by list.</summary>
+    public static IReadOnlyList<string> BuildLines(MonitorRunResult result)
+    {
+        var lines = new List<string>();
+
+        foreach (var diff in result.Diffs)
+        {
+            lines.Add($"{Heading(diff)} - {diff.Summarize()}");
+
+            if (diff.IsBaseline)
+            {
+                lines.Add("  First run: recorded as the baseline, nothing to compare against yet.");
+                continue;
+            }
+
+            if (!diff.HasChanges)
+            {
+                lines.Add("  No movement since the last run.");
+                continue;
+            }
+
+            foreach (var change in diff.Changes)
+            {
+                lines.Add($"  {change.Describe(diff.ListSize)}");
+            }
+        }
+
+        return lines;
+    }
+
+    /// <summary>The toast headline, e.g. "Spotify: 3 new, 1 out, 12 moved".</summary>
+    public static string BuildToastTitle(MonitorRunResult result)
+    {
+        if (result.IsBaseline)
+        {
+            return "Spotify: baseline recorded";
+        }
+
+        if (!result.HasChanges)
+        {
+            return "Spotify: no change in your top lists";
+        }
+
+        int entered = result.Diffs.Sum(d => d.Entered.Count());
+        int left = result.Diffs.Sum(d => d.Left.Count());
+        int moved = result.Diffs.Sum(d => d.Moved.Count());
+
+        var parts = new List<string>();
+        if (entered > 0) parts.Add($"{entered} new");
+        if (left > 0) parts.Add($"{left} out");
+        if (moved > 0) parts.Add($"{moved} moved");
+
+        return $"Spotify: {string.Join(", ", parts)}";
+    }
+
+    /// <summary>
+    /// The toast body: the most notable changes across every list, capped at
+    /// <paramref name="maxLines"/> so the notification stays readable.
+    /// </summary>
+    public static string BuildToastBody(MonitorRunResult result, int maxLines = 5)
+    {
+        if (result.IsBaseline)
+        {
+            int tracked = result.Diffs.Sum(d => d.ListSize);
+            return $"Recorded {tracked} entries across {result.Diffs.Count} lists. Changes will be reported from tomorrow.";
+        }
+
+        if (!result.HasChanges)
+        {
+            return "Your top artists and tracks are unchanged since the last check.";
+        }
+
+        var highlights = result.Diffs
+            .SelectMany(diff => diff.Changes.Select(change => new
+            {
+                Diff = diff,
+                Change = change,
+                Weight = Weight(change, diff.ListSize)
+            }))
+            .OrderByDescending(x => x.Weight)
+            .Take(maxLines)
+            .ToList();
+
+        var body = new StringBuilder();
+        foreach (var highlight in highlights)
+        {
+            body.AppendLine(highlight.Change.Describe(highlight.Diff.ListSize));
+        }
+
+        int remaining = result.Diffs.Sum(d => d.Changes.Count) - highlights.Count;
+        if (remaining > 0)
+        {
+            body.Append($"...and {remaining} more");
+        }
+
+        return body.ToString().TrimEnd();
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private static string Heading(TopDiff diff)
+    {
+        return $"Top {diff.Label} ({SpotifyTimeRange.Describe(diff.TimeRange)})";
+    }
+
+    /// <summary>
+    /// Ranks changes for the toast. Entering or leaving is treated as more notable than a shuffle,
+    /// and anything happening near the top of the list outweighs the same event near the bottom.
+    /// </summary>
+    private static int Weight(EntryChange change, int listSize)
+    {
+        return change.Kind switch
+        {
+            ChangeKind.Entered => listSize + (listSize - change.CurrentRank.Value),
+            ChangeKind.Left => listSize + (listSize - change.PreviousRank.Value),
+            _ => Math.Abs(change.Delta)
+        };
+    }
+
+    #endregion
+
+}

--- a/src/core/monitor/MonitorRunResult.cs
+++ b/src/core/monitor/MonitorRunResult.cs
@@ -1,0 +1,21 @@
+namespace core.monitor;
+
+/// <summary>
+/// Everything one pass of the monitor produced: one diff per tracked list.
+/// </summary>
+public class MonitorRunResult
+{
+
+    public DateTime CapturedAt { get; init; }
+
+    public IReadOnlyList<TopDiff> Diffs { get; init; } = [];
+
+    /// <summary>True when every list was a first capture, so there was nothing to compare against.</summary>
+    public bool IsBaseline => Diffs.Count > 0 && Diffs.All(d => d.IsBaseline);
+
+    public bool HasChanges => Diffs.Any(d => d.HasChanges);
+
+    /// <summary>Snapshots discarded by retention on this run.</summary>
+    public int PrunedSnapshots { get; init; }
+
+}

--- a/src/core/monitor/SpotifyTimeRange.cs
+++ b/src/core/monitor/SpotifyTimeRange.cs
@@ -1,0 +1,33 @@
+using SpotifyAPI.Web;
+
+namespace core.monitor;
+
+public static class SpotifyTimeRange
+{
+
+    /// <summary>
+    /// Maps the CLI/config spelling of a time range onto Spotify's enum. Anything unrecognised
+    /// falls back to the medium term, matching the `top` command's default.
+    /// </summary>
+    public static PersonalizationTopRequest.TimeRange Parse(string range)
+    {
+        return range switch
+        {
+            "short" => PersonalizationTopRequest.TimeRange.ShortTerm,
+            "long" => PersonalizationTopRequest.TimeRange.LongTerm,
+            _ => PersonalizationTopRequest.TimeRange.MediumTerm
+        };
+    }
+
+    /// <summary>A human-readable window, e.g. "the last 4 weeks".</summary>
+    public static string Describe(string range)
+    {
+        return range switch
+        {
+            "short" => "the last 4 weeks",
+            "long" => "all time",
+            _ => "the last 6 months"
+        };
+    }
+
+}

--- a/src/core/monitor/SqliteSnapshotStore.cs
+++ b/src/core/monitor/SqliteSnapshotStore.cs
@@ -1,0 +1,231 @@
+using core.config;
+using Microsoft.Data.Sqlite;
+
+namespace core.monitor;
+
+/// <summary>
+/// Stores snapshots in a single SQLite file, by default alongside the CLI config in
+/// %APPDATA%\spoticli\history.db.
+/// </summary>
+public class SqliteSnapshotStore : ISnapshotStore
+{
+
+    #region Constructors
+
+    public SqliteSnapshotStore() : this(DefaultDatabasePath)
+    {
+    }
+
+    public SqliteSnapshotStore(string databasePath)
+    {
+        DatabasePath = databasePath;
+        _connectionString = new SqliteConnectionStringBuilder
+        {
+            DataSource = databasePath,
+            Mode = SqliteOpenMode.ReadWriteCreate
+        }.ToString();
+    }
+
+    #endregion
+
+    #region Variables
+
+    private readonly string _connectionString;
+
+    #endregion
+
+    #region Properties
+
+    public static string DefaultDatabasePath => Path.Combine(ApplicationConfig.AppConfigRootPath, "history.db");
+
+    public string DatabasePath { get; }
+
+    #endregion
+
+    #region Public Methods
+
+    public async Task InitializeAsync(CancellationToken cancellationToken = default)
+    {
+        var directory = Path.GetDirectoryName(DatabasePath);
+        if (!string.IsNullOrEmpty(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        await using var connection = await OpenAsync(cancellationToken);
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+            CREATE TABLE IF NOT EXISTS snapshots (
+                id           INTEGER PRIMARY KEY AUTOINCREMENT,
+                captured_at  TEXT NOT NULL,
+                entity_type  TEXT NOT NULL,
+                time_range   TEXT NOT NULL
+            );
+
+            CREATE INDEX IF NOT EXISTS ix_snapshots_lookup
+                ON snapshots (entity_type, time_range, captured_at DESC);
+
+            CREATE TABLE IF NOT EXISTS entries (
+                snapshot_id  INTEGER NOT NULL REFERENCES snapshots (id) ON DELETE CASCADE,
+                "rank"       INTEGER NOT NULL,
+                spotify_id   TEXT NOT NULL,
+                name         TEXT NOT NULL,
+                detail       TEXT NOT NULL DEFAULT '',
+                PRIMARY KEY (snapshot_id, "rank")
+            );
+
+            CREATE INDEX IF NOT EXISTS ix_entries_spotify ON entries (spotify_id);
+            """;
+
+        await command.ExecuteNonQueryAsync(cancellationToken);
+    }
+
+    public async Task<TopSnapshot> GetLatestAsync(TopEntityType entityType, string timeRange, CancellationToken cancellationToken = default)
+    {
+        await using var connection = await OpenAsync(cancellationToken);
+
+        await using var header = connection.CreateCommand();
+        header.CommandText = """
+            SELECT id, captured_at
+            FROM snapshots
+            WHERE entity_type = $entityType AND time_range = $timeRange
+            ORDER BY captured_at DESC, id DESC
+            LIMIT 1;
+            """;
+        header.Parameters.AddWithValue("$entityType", Encode(entityType));
+        header.Parameters.AddWithValue("$timeRange", timeRange);
+
+        long snapshotId;
+        DateTime capturedAt;
+
+        await using (var reader = await header.ExecuteReaderAsync(cancellationToken))
+        {
+            if (!await reader.ReadAsync(cancellationToken))
+            {
+                return null;
+            }
+
+            snapshotId = reader.GetInt64(0);
+            capturedAt = ParseTimestamp(reader.GetString(1));
+        }
+
+        return new TopSnapshot
+        {
+            Id = snapshotId,
+            CapturedAt = capturedAt,
+            EntityType = entityType,
+            TimeRange = timeRange,
+            Entries = await ReadEntriesAsync(connection, snapshotId, cancellationToken)
+        };
+    }
+
+    public async Task SaveAsync(TopSnapshot snapshot, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot);
+
+        await using var connection = await OpenAsync(cancellationToken);
+        await using var transaction = await connection.BeginTransactionAsync(cancellationToken);
+
+        await using (var insertSnapshot = connection.CreateCommand())
+        {
+            insertSnapshot.CommandText = """
+                INSERT INTO snapshots (captured_at, entity_type, time_range)
+                VALUES ($capturedAt, $entityType, $timeRange);
+                SELECT last_insert_rowid();
+                """;
+            insertSnapshot.Parameters.AddWithValue("$capturedAt", FormatTimestamp(snapshot.CapturedAt));
+            insertSnapshot.Parameters.AddWithValue("$entityType", Encode(snapshot.EntityType));
+            insertSnapshot.Parameters.AddWithValue("$timeRange", snapshot.TimeRange);
+
+            snapshot.Id = (long)await insertSnapshot.ExecuteScalarAsync(cancellationToken);
+        }
+
+        await using (var insertEntry = connection.CreateCommand())
+        {
+            insertEntry.CommandText = """
+                INSERT INTO entries (snapshot_id, "rank", spotify_id, name, detail)
+                VALUES ($snapshotId, $rank, $spotifyId, $name, $detail);
+                """;
+
+            var snapshotId = insertEntry.Parameters.Add("$snapshotId", SqliteType.Integer);
+            var rank = insertEntry.Parameters.Add("$rank", SqliteType.Integer);
+            var spotifyId = insertEntry.Parameters.Add("$spotifyId", SqliteType.Text);
+            var name = insertEntry.Parameters.Add("$name", SqliteType.Text);
+            var detail = insertEntry.Parameters.Add("$detail", SqliteType.Text);
+
+            snapshotId.Value = snapshot.Id;
+
+            foreach (var entry in snapshot.Entries)
+            {
+                rank.Value = entry.Rank;
+                spotifyId.Value = entry.SpotifyId;
+                name.Value = entry.Name;
+                detail.Value = entry.Detail ?? string.Empty;
+                await insertEntry.ExecuteNonQueryAsync(cancellationToken);
+            }
+        }
+
+        await transaction.CommitAsync(cancellationToken);
+    }
+
+    public async Task<int> PruneAsync(DateTime olderThanUtc, CancellationToken cancellationToken = default)
+    {
+        await using var connection = await OpenAsync(cancellationToken);
+        await using var command = connection.CreateCommand();
+        command.CommandText = "DELETE FROM snapshots WHERE captured_at < $cutoff;";
+        command.Parameters.AddWithValue("$cutoff", FormatTimestamp(olderThanUtc));
+
+        return await command.ExecuteNonQueryAsync(cancellationToken);
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private async Task<SqliteConnection> OpenAsync(CancellationToken cancellationToken)
+    {
+        var connection = new SqliteConnection(_connectionString);
+        await connection.OpenAsync(cancellationToken);
+        return connection;
+    }
+
+    private static async Task<List<TopEntry>> ReadEntriesAsync(SqliteConnection connection, long snapshotId, CancellationToken cancellationToken)
+    {
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT "rank", spotify_id, name, detail
+            FROM entries
+            WHERE snapshot_id = $snapshotId
+            ORDER BY "rank";
+            """;
+        command.Parameters.AddWithValue("$snapshotId", snapshotId);
+
+        var entries = new List<TopEntry>();
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            entries.Add(new TopEntry(reader.GetInt32(0), reader.GetString(1), reader.GetString(2), reader.GetString(3)));
+        }
+
+        return entries;
+    }
+
+    private static string Encode(TopEntityType entityType)
+    {
+        return entityType == TopEntityType.Artist ? "artist" : "track";
+    }
+
+    // Sortable, culture-independent and comparable as text, which is what the ORDER BY relies on.
+    private static string FormatTimestamp(DateTime value)
+    {
+        return value.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ");
+    }
+
+    private static DateTime ParseTimestamp(string value)
+    {
+        return DateTime.Parse(value, null, System.Globalization.DateTimeStyles.RoundtripKind).ToUniversalTime();
+    }
+
+    #endregion
+
+}

--- a/src/core/monitor/TopDiff.cs
+++ b/src/core/monitor/TopDiff.cs
@@ -1,0 +1,76 @@
+namespace core.monitor;
+
+/// <summary>
+/// The change between two snapshots of the same list.
+/// </summary>
+public class TopDiff
+{
+
+    #region Properties
+
+    public TopEntityType EntityType { get; init; }
+
+    public string TimeRange { get; init; }
+
+    /// <summary>Null on the very first run, when there is nothing to compare against.</summary>
+    public DateTime? PreviousCapturedAt { get; init; }
+
+    public DateTime CurrentCapturedAt { get; init; }
+
+    /// <summary>Number of entries in the current snapshot - the "top N" the report talks about.</summary>
+    public int ListSize { get; init; }
+
+    /// <summary>
+    /// Entries that entered, then left, then moved (largest move first). Entries that held their
+    /// rank are excluded.
+    /// </summary>
+    public IReadOnlyList<EntryChange> Changes { get; init; } = [];
+
+    /// <summary>True when there was no previous snapshot, so this run only established a baseline.</summary>
+    public bool IsBaseline => PreviousCapturedAt == null;
+
+    public bool HasChanges => Changes.Count > 0;
+
+    public string Label => EntityType == TopEntityType.Artist ? "artists" : "tracks";
+
+    public IEnumerable<EntryChange> Entered => Changes.Where(c => c.Kind == ChangeKind.Entered);
+
+    public IEnumerable<EntryChange> Left => Changes.Where(c => c.Kind == ChangeKind.Left);
+
+    public IEnumerable<EntryChange> Moved =>
+        Changes.Where(c => c.Kind is ChangeKind.MovedUp or ChangeKind.MovedDown);
+
+    #endregion
+
+    #region Public Methods
+
+    /// <summary>
+    /// A short headline such as "Top artists: 2 new, 1 out, 6 moved".
+    /// </summary>
+    public string Summarize()
+    {
+        if (IsBaseline)
+        {
+            return $"Top {Label}: baseline of {ListSize} recorded";
+        }
+
+        if (!HasChanges)
+        {
+            return $"Top {Label}: no change";
+        }
+
+        var parts = new List<string>();
+        int entered = Entered.Count();
+        int left = Left.Count();
+        int moved = Moved.Count();
+
+        if (entered > 0) parts.Add($"{entered} new");
+        if (left > 0) parts.Add($"{left} out");
+        if (moved > 0) parts.Add($"{moved} moved");
+
+        return $"Top {Label}: {string.Join(", ", parts)}";
+    }
+
+    #endregion
+
+}

--- a/src/core/monitor/TopDiffCalculator.cs
+++ b/src/core/monitor/TopDiffCalculator.cs
@@ -1,0 +1,120 @@
+namespace core.monitor;
+
+/// <summary>
+/// Compares two snapshots of the same list. Entries are matched on their Spotify id, so a
+/// rename or a re-release does not read as one entry leaving and another entering.
+/// </summary>
+public static class TopDiffCalculator
+{
+
+    #region Public Methods
+
+    /// <summary>
+    /// Builds the diff from <paramref name="previous"/> to <paramref name="current"/>. Pass a null
+    /// previous snapshot for the first ever run; the result is then a baseline with no changes.
+    /// </summary>
+    public static TopDiff Compare(TopSnapshot previous, TopSnapshot current)
+    {
+        ArgumentNullException.ThrowIfNull(current);
+
+        if (previous == null)
+        {
+            return new TopDiff
+            {
+                EntityType = current.EntityType,
+                TimeRange = current.TimeRange,
+                PreviousCapturedAt = null,
+                CurrentCapturedAt = current.CapturedAt,
+                ListSize = current.Entries.Count,
+                Changes = []
+            };
+        }
+
+        var previousById = Index(previous.Entries);
+        var currentById = Index(current.Entries);
+
+        var entered = new List<EntryChange>();
+        var moved = new List<EntryChange>();
+
+        foreach (var entry in current.Entries.OrderBy(e => e.Rank))
+        {
+            if (!previousById.TryGetValue(entry.SpotifyId, out var before))
+            {
+                entered.Add(new EntryChange
+                {
+                    Kind = ChangeKind.Entered,
+                    SpotifyId = entry.SpotifyId,
+                    Name = entry.Name,
+                    Detail = entry.Detail,
+                    PreviousRank = null,
+                    CurrentRank = entry.Rank
+                });
+                continue;
+            }
+
+            if (before.Rank == entry.Rank)
+            {
+                continue;
+            }
+
+            moved.Add(new EntryChange
+            {
+                // A smaller rank number is a better position, so a drop in rank is a move up.
+                Kind = entry.Rank < before.Rank ? ChangeKind.MovedUp : ChangeKind.MovedDown,
+                SpotifyId = entry.SpotifyId,
+                Name = entry.Name,
+                Detail = entry.Detail,
+                PreviousRank = before.Rank,
+                CurrentRank = entry.Rank
+            });
+        }
+
+        var left = previous.Entries
+            .Where(e => !currentById.ContainsKey(e.SpotifyId))
+            .OrderBy(e => e.Rank)
+            .Select(e => new EntryChange
+            {
+                Kind = ChangeKind.Left,
+                SpotifyId = e.SpotifyId,
+                Name = e.Name,
+                Detail = e.Detail,
+                PreviousRank = e.Rank,
+                CurrentRank = null
+            })
+            .ToList();
+
+        var changes = new List<EntryChange>(entered.Count + left.Count + moved.Count);
+        changes.AddRange(entered);
+        changes.AddRange(left);
+        changes.AddRange(moved.OrderByDescending(c => Math.Abs(c.Delta)).ThenBy(c => c.CurrentRank));
+
+        return new TopDiff
+        {
+            EntityType = current.EntityType,
+            TimeRange = current.TimeRange,
+            PreviousCapturedAt = previous.CapturedAt,
+            CurrentCapturedAt = current.CapturedAt,
+            ListSize = current.Entries.Count,
+            Changes = changes
+        };
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private static Dictionary<string, TopEntry> Index(IReadOnlyList<TopEntry> entries)
+    {
+        var index = new Dictionary<string, TopEntry>(entries.Count, StringComparer.Ordinal);
+        foreach (var entry in entries)
+        {
+            // Spotify should not repeat an id within one list, but a duplicate must not crash the run.
+            index.TryAdd(entry.SpotifyId, entry);
+        }
+
+        return index;
+    }
+
+    #endregion
+
+}

--- a/src/core/monitor/TopEntityType.cs
+++ b/src/core/monitor/TopEntityType.cs
@@ -1,0 +1,7 @@
+namespace core.monitor;
+
+public enum TopEntityType
+{
+    Artist,
+    Track
+}

--- a/src/core/monitor/TopEntry.cs
+++ b/src/core/monitor/TopEntry.cs
@@ -1,0 +1,15 @@
+namespace core.monitor;
+
+/// <summary>
+/// A single ranked artist or track within a snapshot.
+/// </summary>
+/// <param name="Rank">1-based position in the top list.</param>
+/// <param name="SpotifyId">Spotify's stable id - what entries are matched on across snapshots.</param>
+/// <param name="Name">Artist or track name.</param>
+/// <param name="Detail">Supporting text: performing artists for a track, genres for an artist.</param>
+public record TopEntry(int Rank, string SpotifyId, string Name, string Detail)
+{
+
+    public string Display => string.IsNullOrEmpty(Detail) ? Name : $"{Name} - {Detail}";
+
+}

--- a/src/core/monitor/TopMonitorService.cs
+++ b/src/core/monitor/TopMonitorService.cs
@@ -1,0 +1,136 @@
+using core.config;
+using core.services;
+using SpotifyAPI.Web;
+
+namespace core.monitor;
+
+public class TopMonitorService : ITopMonitorService
+{
+
+    #region Constructors
+
+    public TopMonitorService(ApplicationConfig config, ISpotifyService spotifyService, ISnapshotStore store)
+    {
+        _config = config;
+        _spotifyService = spotifyService;
+        _store = store;
+    }
+
+    #endregion
+
+    #region Variables
+
+    private readonly ApplicationConfig _config;
+    private readonly ISpotifyService _spotifyService;
+    private readonly ISnapshotStore _store;
+
+    #endregion
+
+    #region Public Methods
+
+    public async Task<MonitorRunResult> RunAsync(bool persist = true, CancellationToken cancellationToken = default)
+    {
+        var spotify = RequireLoggedInClient();
+        var settings = _config.Monitor;
+        int limit = Math.Clamp(settings.Limit, 1, 50);
+        var ranges = settings.TimeRanges is { Length: > 0 } ? settings.TimeRanges : ["short"];
+
+        await _store.InitializeAsync(cancellationToken);
+
+        var capturedAt = DateTime.UtcNow;
+        var diffs = new List<TopDiff>();
+
+        foreach (var range in ranges)
+        {
+            diffs.Add(await CompareListAsync(spotify, TopEntityType.Artist, range, limit, capturedAt, persist, cancellationToken));
+            diffs.Add(await CompareListAsync(spotify, TopEntityType.Track, range, limit, capturedAt, persist, cancellationToken));
+        }
+
+        int pruned = 0;
+        if (persist && settings.RetentionDays > 0)
+        {
+            pruned = await _store.PruneAsync(capturedAt.AddDays(-settings.RetentionDays), cancellationToken);
+        }
+
+        return new MonitorRunResult
+        {
+            CapturedAt = capturedAt,
+            Diffs = diffs,
+            PrunedSnapshots = pruned
+        };
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private async Task<TopDiff> CompareListAsync(
+        SpotifyClient spotify,
+        TopEntityType entityType,
+        string range,
+        int limit,
+        DateTime capturedAt,
+        bool persist,
+        CancellationToken cancellationToken)
+    {
+        var current = new TopSnapshot
+        {
+            CapturedAt = capturedAt,
+            EntityType = entityType,
+            TimeRange = range,
+            Entries = entityType == TopEntityType.Artist
+                ? await FetchArtistsAsync(spotify, range, limit, cancellationToken)
+                : await FetchTracksAsync(spotify, range, limit, cancellationToken)
+        };
+
+        var previous = await _store.GetLatestAsync(entityType, range, cancellationToken);
+        var diff = TopDiffCalculator.Compare(previous, current);
+
+        if (persist)
+        {
+            await _store.SaveAsync(current, cancellationToken);
+        }
+
+        return diff;
+    }
+
+    private static async Task<List<TopEntry>> FetchArtistsAsync(SpotifyClient spotify, string range, int limit, CancellationToken cancellationToken)
+    {
+        var request = new PersonalizationTopRequest { Limit = limit, TimeRangeParam = SpotifyTimeRange.Parse(range) };
+        var result = await spotify.Personalization.GetTopArtists(request, cancellationToken);
+
+        int rank = 1;
+        return (result.Items ?? [])
+            .Select(a => new TopEntry(rank++, a.Id, a.Name, string.Join(", ", a.Genres.Take(2))))
+            .ToList();
+    }
+
+    private static async Task<List<TopEntry>> FetchTracksAsync(SpotifyClient spotify, string range, int limit, CancellationToken cancellationToken)
+    {
+        var request = new PersonalizationTopRequest { Limit = limit, TimeRangeParam = SpotifyTimeRange.Parse(range) };
+        var result = await spotify.Personalization.GetTopTracks(request, cancellationToken);
+
+        int rank = 1;
+        return (result.Items ?? [])
+            .Select(t => new TopEntry(rank++, t.Id, t.Name, string.Join(", ", t.Artists.Select(a => a.Name))))
+            .ToList();
+    }
+
+    /// <summary>
+    /// The CLI variant of this check exits the process, which is the wrong behaviour for an
+    /// unattended run - a thrown exception lets the caller log it and set an exit code.
+    /// </summary>
+    private SpotifyClient RequireLoggedInClient()
+    {
+        if (_spotifyService.Spotify == null || _spotifyService.Config.Authenticator is not AuthorizationCodeAuthenticator)
+        {
+            throw new InvalidOperationException(
+                "No Spotify user login found. Run `sp0 login` as this user before the monitor can read your top lists.");
+        }
+
+        return _spotifyService.Spotify;
+    }
+
+    #endregion
+
+}

--- a/src/core/monitor/TopSnapshot.cs
+++ b/src/core/monitor/TopSnapshot.cs
@@ -1,0 +1,25 @@
+namespace core.monitor;
+
+/// <summary>
+/// One capture of a single top list (artists or tracks, for one time range).
+/// </summary>
+public class TopSnapshot
+{
+
+    #region Properties
+
+    /// <summary>Store-assigned row id. Zero until the snapshot has been saved.</summary>
+    public long Id { get; set; }
+
+    public DateTime CapturedAt { get; set; }
+
+    public TopEntityType EntityType { get; set; }
+
+    /// <summary>Spotify time range: "short", "medium" or "long".</summary>
+    public string TimeRange { get; set; }
+
+    public IReadOnlyList<TopEntry> Entries { get; set; } = [];
+
+    #endregion
+
+}

--- a/src/monitor/MonitorOptions.cs
+++ b/src/monitor/MonitorOptions.cs
@@ -1,0 +1,17 @@
+using CommandLine;
+
+namespace monitor;
+
+public class MonitorOptions
+{
+
+    [Option("dry-run", HelpText = "Fetch and report the diff without writing anything to the history database.")]
+    public bool DryRun { get; set; }
+
+    [Option("no-notify", HelpText = "Skip the toast notification; write the report to the console and log only.")]
+    public bool NoNotify { get; set; }
+
+    [Option("notify-always", HelpText = "Show a toast even when nothing changed. By default a no-change run stays quiet.")]
+    public bool NotifyAlways { get; set; }
+
+}

--- a/src/monitor/Program.cs
+++ b/src/monitor/Program.cs
@@ -1,0 +1,81 @@
+using CommandLine;
+using core.config;
+using core.monitor;
+using core.services;
+using Microsoft.Extensions.DependencyInjection;
+using monitor;
+using Serilog;
+
+var parsed = Parser.Default.ParseArguments<MonitorOptions>(args);
+if (parsed.Errors.Any())
+{
+    return 2;
+}
+
+var options = parsed.Value;
+
+Log.Logger = new LoggerConfiguration()
+    .MinimumLevel.Information()
+    .WriteTo.Console()
+    .WriteTo.File(
+        Path.Combine(ApplicationConfig.AppConfigRootPath, "logs", "monitor-.log"),
+        rollingInterval: RollingInterval.Day,
+        retainedFileCountLimit: 30)
+    .CreateLogger();
+
+try
+{
+    var config = ApplicationConfig.Load();
+
+    var services = new ServiceCollection()
+        .AddSingleton(config)
+        .AddSingleton<ISpotifyService, SpotifyService>()
+        .AddSingleton<ISnapshotStore>(_ => new SqliteSnapshotStore())
+        .AddSingleton<ITopMonitorService, TopMonitorService>()
+        .AddSingleton<INotifier, ToastNotifier>()
+        .BuildServiceProvider();
+
+    Log.Information(
+        "Monitor run started (ranges: {Ranges}, limit: {Limit}, dry run: {DryRun})",
+        string.Join(", ", config.Monitor.TimeRanges),
+        config.Monitor.Limit,
+        options.DryRun);
+
+    var result = await services.GetRequiredService<ITopMonitorService>().RunAsync(!options.DryRun);
+
+    foreach (var line in MonitorReport.BuildLines(result))
+    {
+        Log.Information("{Line}", line);
+    }
+
+    if (result.PrunedSnapshots > 0)
+    {
+        Log.Information("Pruned {Count} snapshots past the retention window", result.PrunedSnapshots);
+    }
+
+    if (options.NoNotify)
+    {
+        Log.Information("Notification skipped (--no-notify)");
+    }
+    else if (!result.HasChanges && !result.IsBaseline && !options.NotifyAlways)
+    {
+        // Nothing moved. A daily toast saying so would only train you to ignore them.
+        Log.Information("Notification skipped: nothing changed");
+    }
+    else
+    {
+        await services.GetRequiredService<INotifier>().NotifyAsync(result);
+    }
+
+    Log.Information("Monitor run completed");
+    return 0;
+}
+catch (Exception ex)
+{
+    Log.Fatal(ex, "Monitor run failed");
+    return 1;
+}
+finally
+{
+    await Log.CloseAndFlushAsync();
+}

--- a/src/monitor/ToastNotifier.cs
+++ b/src/monitor/ToastNotifier.cs
@@ -1,0 +1,102 @@
+using System.Runtime.Versioning;
+using System.Security;
+using core.monitor;
+using Microsoft.Win32;
+using Serilog;
+using Windows.Data.Xml.Dom;
+using Windows.UI.Notifications;
+
+namespace monitor;
+
+/// <summary>
+/// Raises a Windows toast through the WinRT notification APIs.
+///
+/// An unpackaged desktop app can only post toasts under an AppUserModelID that Windows knows
+/// about, so the notifier registers its own AUMID under HKCU on first use. That registration is
+/// per-user, idempotent, and is what makes the toast land in Action Center with a proper name
+/// instead of being dropped silently.
+/// </summary>
+[SupportedOSPlatform("windows10.0.17763.0")]
+public class ToastNotifier : INotifier
+{
+
+    #region Constants
+
+    public const string AppUserModelId = "spoticli.TopMonitor";
+
+    private const string DisplayName = "spoticli";
+    private const int MaxBodyLines = 3;
+
+    #endregion
+
+    #region Public Methods
+
+    public Task NotifyAsync(MonitorRunResult result, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            EnsureRegistered();
+
+            var document = new XmlDocument();
+            document.LoadXml(BuildToastXml(result));
+
+            ToastNotificationManager.CreateToastNotifier(AppUserModelId).Show(new ToastNotification(document));
+            Log.Information("Toast notification raised");
+        }
+        catch (Exception ex)
+        {
+            // A failed notification must not fail the run - the snapshot is already saved and the
+            // full report is in the log.
+            Log.Error(ex, "Could not raise the toast notification");
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Writes the per-user AUMID registration Windows needs before it will accept toasts from an
+    /// unpackaged app. Safe to call repeatedly.
+    /// </summary>
+    public static void EnsureRegistered()
+    {
+        using var key = Registry.CurrentUser.CreateSubKey($@"Software\Classes\AppUserModelId\{AppUserModelId}");
+        key?.SetValue("DisplayName", DisplayName, RegistryValueKind.String);
+    }
+
+    /// <summary>Removes the AUMID registration, used by the uninstall path.</summary>
+    public static void Unregister()
+    {
+        Registry.CurrentUser.DeleteSubKeyTree($@"Software\Classes\AppUserModelId\{AppUserModelId}", throwOnMissingSubKey: false);
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private static string BuildToastXml(MonitorRunResult result)
+    {
+        string title = MonitorReport.BuildToastTitle(result);
+        var body = MonitorReport
+            .BuildToastBody(result, MaxBodyLines)
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        // ToastGeneric allows a title plus three body lines; anything longer belongs in the log.
+        var texts = body
+            .Take(MaxBodyLines)
+            .Select(line => $"<text>{SecurityElement.Escape(line)}</text>");
+
+        return $"""
+            <toast activationType="foreground">
+              <visual>
+                <binding template="ToastGeneric">
+                  <text>{SecurityElement.Escape(title)}</text>
+                  {string.Join(Environment.NewLine, texts)}
+                </binding>
+              </visual>
+            </toast>
+            """;
+    }
+
+    #endregion
+
+}

--- a/src/monitor/monitor.csproj
+++ b/src/monitor/monitor.csproj
@@ -1,0 +1,38 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <AssemblyName>sp0-monitor</AssemblyName>
+    <!-- The Windows TFM brings in the WinRT projection the toast notifier needs. -->
+    <TargetFramework>net10.0-windows10.0.19041.0</TargetFramework>
+    <SupportedOSPlatformVersion>10.0.17763.0</SupportedOSPlatformVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <OutputPath>..\..\build\debug</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <OutputPath>..\..\build\release</OutputPath>
+    <PublishSingleFile>true</PublishSingleFile>
+    <SelfContained>true</SelfContained>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <PublishReadyToRun>true</PublishReadyToRun>
+    <DebugType>embedded</DebugType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="CommandLineParser" Version="2.9.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+    <PackageReference Include="Serilog" Version="4.4.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\core\core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/core.test/MonitorReportTests.cs
+++ b/tests/core.test/MonitorReportTests.cs
@@ -1,0 +1,131 @@
+using core.monitor;
+
+namespace core.test;
+
+public class MonitorReportTests
+{
+
+    #region Helper Methods
+
+    private static readonly DateTime Yesterday = new(2026, 7, 27, 0, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime Today = new(2026, 7, 28, 0, 0, 0, DateTimeKind.Utc);
+
+    private static TopSnapshot Snapshot(DateTime capturedAt, TopEntityType entityType, params string[] names)
+    {
+        return new TopSnapshot
+        {
+            CapturedAt = capturedAt,
+            EntityType = entityType,
+            TimeRange = "short",
+            Entries = names
+                .Select((name, index) => new TopEntry(index + 1, $"id-{name}", name, string.Empty))
+                .ToList()
+        };
+    }
+
+    private static MonitorRunResult Result(params TopDiff[] diffs)
+    {
+        return new MonitorRunResult { CapturedAt = Today, Diffs = diffs };
+    }
+
+    #endregion
+
+    #region Tests
+
+    [Test]
+    public void BuildToastTitle_OnFirstRun_SaysBaseline()
+    {
+        var result = Result(TopDiffCalculator.Compare(null, Snapshot(Today, TopEntityType.Artist, "a", "b")));
+
+        Assert.That(MonitorReport.BuildToastTitle(result), Is.EqualTo("Spotify: baseline recorded"));
+    }
+
+    [Test]
+    public void BuildToastTitle_TotalsChangesAcrossEveryList()
+    {
+        var artists = TopDiffCalculator.Compare(
+            Snapshot(Yesterday, TopEntityType.Artist, "a", "b"),
+            Snapshot(Today, TopEntityType.Artist, "b", "a"));
+        var tracks = TopDiffCalculator.Compare(
+            Snapshot(Yesterday, TopEntityType.Track, "x", "y"),
+            Snapshot(Today, TopEntityType.Track, "z", "x"));
+
+        // Artists: two swapped. Tracks: z entered, y left, x slipped one.
+        Assert.That(MonitorReport.BuildToastTitle(Result(artists, tracks)), Is.EqualTo("Spotify: 1 new, 1 out, 3 moved"));
+    }
+
+    [Test]
+    public void BuildToastTitle_WhenNothingMoved_SaysNoChange()
+    {
+        var diff = TopDiffCalculator.Compare(
+            Snapshot(Yesterday, TopEntityType.Artist, "a", "b"),
+            Snapshot(Today, TopEntityType.Artist, "a", "b"));
+
+        Assert.That(MonitorReport.BuildToastTitle(Result(diff)), Is.EqualTo("Spotify: no change in your top lists"));
+    }
+
+    [Test]
+    public void BuildToastBody_CapsLinesAndCountsTheRemainder()
+    {
+        var previous = Snapshot(Yesterday, TopEntityType.Artist, "a", "b", "c", "d", "e", "f");
+        var current = Snapshot(Today, TopEntityType.Artist, "f", "e", "d", "c", "b", "a");
+
+        var body = MonitorReport.BuildToastBody(Result(TopDiffCalculator.Compare(previous, current)), maxLines: 3);
+        var lines = body.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+
+        Assert.Multiple(() =>
+        {
+            // Three highlights plus the "and N more" tail; all six entries moved.
+            Assert.That(lines, Has.Length.EqualTo(4));
+            Assert.That(lines[3].Trim(), Is.EqualTo("...and 3 more"));
+        });
+    }
+
+    [Test]
+    public void BuildToastBody_RanksEntriesAndExitsAboveSmallShuffles()
+    {
+        var previous = Snapshot(Yesterday, TopEntityType.Artist, "a", "b", "c");
+        var current = Snapshot(Today, TopEntityType.Artist, "a", "c", "z");
+
+        // "z" entered and "b" left; "c" only moved one place, so it should be squeezed out.
+        var body = MonitorReport.BuildToastBody(Result(TopDiffCalculator.Compare(previous, current)), maxLines: 2);
+        var lines = body.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        var highlights = lines.Take(2).ToList();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(highlights, Has.Exactly(1).Contains("entered"));
+            Assert.That(highlights, Has.Exactly(1).Contains("no longer"));
+            Assert.That(highlights, Has.None.Contains("moved"));
+        });
+    }
+
+    [Test]
+    public void BuildLines_IncludesAHeadingAndEveryChange()
+    {
+        var diff = TopDiffCalculator.Compare(
+            Snapshot(Yesterday, TopEntityType.Track, "a", "b"),
+            Snapshot(Today, TopEntityType.Track, "b", "a"));
+
+        var lines = MonitorReport.BuildLines(Result(diff));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(lines[0], Does.Contain("Top tracks (the last 4 weeks)"));
+            Assert.That(lines[0], Does.Contain("2 moved"));
+            Assert.That(lines, Has.Count.EqualTo(3));
+        });
+    }
+
+    [Test]
+    public void BuildLines_OnFirstRun_ExplainsThereIsNothingToCompare()
+    {
+        var lines = MonitorReport.BuildLines(
+            Result(TopDiffCalculator.Compare(null, Snapshot(Today, TopEntityType.Artist, "a"))));
+
+        Assert.That(lines[1], Does.Contain("baseline"));
+    }
+
+    #endregion
+
+}

--- a/tests/core.test/SqliteSnapshotStoreTests.cs
+++ b/tests/core.test/SqliteSnapshotStoreTests.cs
@@ -1,0 +1,188 @@
+using core.monitor;
+
+namespace core.test;
+
+public class SqliteSnapshotStoreTests
+{
+
+    #region Setup
+
+    private string _databasePath;
+    private SqliteSnapshotStore _store;
+
+    [SetUp]
+    public async Task Setup()
+    {
+        _databasePath = Path.Combine(Path.GetTempPath(), $"spoticli-test-{Guid.NewGuid():N}.db");
+        _store = new SqliteSnapshotStore(_databasePath);
+        await _store.InitializeAsync();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+        if (File.Exists(_databasePath))
+        {
+            File.Delete(_databasePath);
+        }
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private static TopSnapshot Snapshot(DateTime capturedAt, TopEntityType entityType, string timeRange, params string[] names)
+    {
+        return new TopSnapshot
+        {
+            CapturedAt = capturedAt,
+            EntityType = entityType,
+            TimeRange = timeRange,
+            Entries = names
+                .Select((name, index) => new TopEntry(index + 1, $"id-{name}", name, $"detail-{name}"))
+                .ToList()
+        };
+    }
+
+    #endregion
+
+    #region Tests
+
+    [Test]
+    public void InitializeAsync_IsSafeToCallTwice()
+    {
+        // Setup already initialised the store; every run of the monitor calls this again.
+        Assert.DoesNotThrowAsync(() => _store.InitializeAsync());
+    }
+
+    [Test]
+    public async Task GetLatestAsync_WithEmptyStore_ReturnsNull()
+    {
+        var latest = await _store.GetLatestAsync(TopEntityType.Artist, "short");
+
+        Assert.That(latest, Is.Null);
+    }
+
+    [Test]
+    public async Task SaveAsync_ThenGetLatest_RoundTripsEveryField()
+    {
+        var capturedAt = new DateTime(2026, 7, 28, 4, 30, 15, DateTimeKind.Utc);
+        await _store.SaveAsync(Snapshot(capturedAt, TopEntityType.Track, "medium", "Alpha", "Beta"));
+
+        var latest = await _store.GetLatestAsync(TopEntityType.Track, "medium");
+
+        Assert.That(latest, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(latest.CapturedAt, Is.EqualTo(capturedAt));
+            Assert.That(latest.EntityType, Is.EqualTo(TopEntityType.Track));
+            Assert.That(latest.TimeRange, Is.EqualTo("medium"));
+            Assert.That(latest.Entries, Has.Count.EqualTo(2));
+            Assert.That(latest.Entries[0].Rank, Is.EqualTo(1));
+            Assert.That(latest.Entries[0].SpotifyId, Is.EqualTo("id-Alpha"));
+            Assert.That(latest.Entries[0].Name, Is.EqualTo("Alpha"));
+            Assert.That(latest.Entries[0].Detail, Is.EqualTo("detail-Alpha"));
+        });
+    }
+
+    [Test]
+    public async Task SaveAsync_AssignsTheSnapshotId()
+    {
+        var snapshot = Snapshot(DateTime.UtcNow, TopEntityType.Artist, "short", "Alpha");
+
+        await _store.SaveAsync(snapshot);
+
+        Assert.That(snapshot.Id, Is.GreaterThan(0));
+    }
+
+    [Test]
+    public async Task GetLatestAsync_ReturnsTheMostRecentSnapshot()
+    {
+        var older = new DateTime(2026, 7, 26, 0, 0, 0, DateTimeKind.Utc);
+        var newer = new DateTime(2026, 7, 28, 0, 0, 0, DateTimeKind.Utc);
+
+        await _store.SaveAsync(Snapshot(older, TopEntityType.Artist, "short", "Old"));
+        await _store.SaveAsync(Snapshot(newer, TopEntityType.Artist, "short", "New"));
+
+        var latest = await _store.GetLatestAsync(TopEntityType.Artist, "short");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(latest.CapturedAt, Is.EqualTo(newer));
+            Assert.That(latest.Entries[0].Name, Is.EqualTo("New"));
+        });
+    }
+
+    [Test]
+    public async Task GetLatestAsync_KeepsListsWithDifferentTypesAndRangesApart()
+    {
+        var capturedAt = DateTime.UtcNow;
+        await _store.SaveAsync(Snapshot(capturedAt, TopEntityType.Artist, "short", "ShortArtist"));
+        await _store.SaveAsync(Snapshot(capturedAt, TopEntityType.Artist, "long", "LongArtist"));
+        await _store.SaveAsync(Snapshot(capturedAt, TopEntityType.Track, "short", "ShortTrack"));
+
+        var shortArtists = await _store.GetLatestAsync(TopEntityType.Artist, "short");
+        var longArtists = await _store.GetLatestAsync(TopEntityType.Artist, "long");
+        var shortTracks = await _store.GetLatestAsync(TopEntityType.Track, "short");
+        var mediumTracks = await _store.GetLatestAsync(TopEntityType.Track, "medium");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(shortArtists.Entries[0].Name, Is.EqualTo("ShortArtist"));
+            Assert.That(longArtists.Entries[0].Name, Is.EqualTo("LongArtist"));
+            Assert.That(shortTracks.Entries[0].Name, Is.EqualTo("ShortTrack"));
+            Assert.That(mediumTracks, Is.Null);
+        });
+    }
+
+    [Test]
+    public async Task PruneAsync_RemovesOnlySnapshotsBeforeTheCutoff()
+    {
+        var old = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var recent = new DateTime(2026, 7, 28, 0, 0, 0, DateTimeKind.Utc);
+
+        await _store.SaveAsync(Snapshot(old, TopEntityType.Artist, "short", "Old"));
+        await _store.SaveAsync(Snapshot(recent, TopEntityType.Artist, "short", "Recent"));
+
+        int pruned = await _store.PruneAsync(new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+
+        var latest = await _store.GetLatestAsync(TopEntityType.Artist, "short");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(pruned, Is.EqualTo(1));
+            Assert.That(latest.Entries[0].Name, Is.EqualTo("Recent"));
+        });
+    }
+
+    [Test]
+    public async Task PruneAsync_CascadesToTheEntriesOfDeletedSnapshots()
+    {
+        var old = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        await _store.SaveAsync(Snapshot(old, TopEntityType.Artist, "short", "Old"));
+
+        await _store.PruneAsync(new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+
+        Assert.That(await _store.GetLatestAsync(TopEntityType.Artist, "short"), Is.Null);
+    }
+
+    [Test]
+    public async Task SaveAsync_StoresAFullFiftyEntryList()
+    {
+        var names = Enumerable.Range(1, 50).Select(i => $"Entry{i}").ToArray();
+        await _store.SaveAsync(Snapshot(DateTime.UtcNow, TopEntityType.Track, "short", names));
+
+        var latest = await _store.GetLatestAsync(TopEntityType.Track, "short");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(latest.Entries, Has.Count.EqualTo(50));
+            Assert.That(latest.Entries[49].Rank, Is.EqualTo(50));
+            Assert.That(latest.Entries.Select(e => e.Rank), Is.Ordered);
+        });
+    }
+
+    #endregion
+
+}

--- a/tests/core.test/TopDiffCalculatorTests.cs
+++ b/tests/core.test/TopDiffCalculatorTests.cs
@@ -1,0 +1,209 @@
+using core.monitor;
+
+namespace core.test;
+
+public class TopDiffCalculatorTests
+{
+
+    #region Helper Methods
+
+    private static TopSnapshot Snapshot(DateTime capturedAt, params string[] spotifyIds)
+    {
+        return new TopSnapshot
+        {
+            CapturedAt = capturedAt,
+            EntityType = TopEntityType.Artist,
+            TimeRange = "short",
+            Entries = spotifyIds
+                .Select((id, index) => new TopEntry(index + 1, id, $"Artist {id}", string.Empty))
+                .ToList()
+        };
+    }
+
+    private static EntryChange ChangeFor(TopDiff diff, string spotifyId)
+    {
+        return diff.Changes.Single(c => c.SpotifyId == spotifyId);
+    }
+
+    private static readonly DateTime Yesterday = new(2026, 7, 27, 0, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime Today = new(2026, 7, 28, 0, 0, 0, DateTimeKind.Utc);
+
+    #endregion
+
+    #region Tests
+
+    [Test]
+    public void Compare_WithNoPreviousSnapshot_IsBaselineWithNoChanges()
+    {
+        var diff = TopDiffCalculator.Compare(null, Snapshot(Today, "a", "b", "c"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(diff.IsBaseline, Is.True);
+            Assert.That(diff.HasChanges, Is.False);
+            Assert.That(diff.ListSize, Is.EqualTo(3));
+            Assert.That(diff.PreviousCapturedAt, Is.Null);
+        });
+    }
+
+    [Test]
+    public void Compare_WithIdenticalSnapshots_ReportsNoChanges()
+    {
+        var diff = TopDiffCalculator.Compare(
+            Snapshot(Yesterday, "a", "b", "c"),
+            Snapshot(Today, "a", "b", "c"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(diff.IsBaseline, Is.False);
+            Assert.That(diff.HasChanges, Is.False);
+        });
+    }
+
+    [Test]
+    public void Compare_WhenEntryClimbs_ReportsMovedUpWithPositiveDelta()
+    {
+        var diff = TopDiffCalculator.Compare(
+            Snapshot(Yesterday, "a", "b", "c"),
+            Snapshot(Today, "c", "a", "b"));
+
+        var change = ChangeFor(diff, "c");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(change.Kind, Is.EqualTo(ChangeKind.MovedUp));
+            Assert.That(change.PreviousRank, Is.EqualTo(3));
+            Assert.That(change.CurrentRank, Is.EqualTo(1));
+            Assert.That(change.Delta, Is.EqualTo(2));
+        });
+    }
+
+    [Test]
+    public void Compare_WhenEntrySlips_ReportsMovedDownWithNegativeDelta()
+    {
+        var diff = TopDiffCalculator.Compare(
+            Snapshot(Yesterday, "a", "b", "c"),
+            Snapshot(Today, "b", "c", "a"));
+
+        var change = ChangeFor(diff, "a");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(change.Kind, Is.EqualTo(ChangeKind.MovedDown));
+            Assert.That(change.PreviousRank, Is.EqualTo(1));
+            Assert.That(change.CurrentRank, Is.EqualTo(3));
+            Assert.That(change.Delta, Is.EqualTo(-2));
+        });
+    }
+
+    [Test]
+    public void Compare_WhenEntryIsNew_ReportsEnteredWithNoPreviousRank()
+    {
+        var diff = TopDiffCalculator.Compare(
+            Snapshot(Yesterday, "a", "b"),
+            Snapshot(Today, "a", "z", "b"));
+
+        var change = ChangeFor(diff, "z");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(change.Kind, Is.EqualTo(ChangeKind.Entered));
+            Assert.That(change.PreviousRank, Is.Null);
+            Assert.That(change.CurrentRank, Is.EqualTo(2));
+            Assert.That(change.Delta, Is.EqualTo(0));
+        });
+    }
+
+    [Test]
+    public void Compare_WhenEntryDropsOut_ReportsLeftWithNoCurrentRank()
+    {
+        var diff = TopDiffCalculator.Compare(
+            Snapshot(Yesterday, "a", "b", "c"),
+            Snapshot(Today, "a", "b"));
+
+        var change = ChangeFor(diff, "c");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(change.Kind, Is.EqualTo(ChangeKind.Left));
+            Assert.That(change.PreviousRank, Is.EqualTo(3));
+            Assert.That(change.CurrentRank, Is.Null);
+            Assert.That(change.Describe(2), Does.Contain("no longer in the top 2"));
+        });
+    }
+
+    [Test]
+    public void Compare_MatchesOnSpotifyIdNotName()
+    {
+        var previous = new TopSnapshot
+        {
+            CapturedAt = Yesterday,
+            EntityType = TopEntityType.Artist,
+            TimeRange = "short",
+            Entries = [new TopEntry(1, "id-1", "Old Name", string.Empty)]
+        };
+        var current = new TopSnapshot
+        {
+            CapturedAt = Today,
+            EntityType = TopEntityType.Artist,
+            TimeRange = "short",
+            Entries = [new TopEntry(1, "id-1", "New Name", string.Empty)]
+        };
+
+        var diff = TopDiffCalculator.Compare(previous, current);
+
+        // A rename at the same rank is not a change worth reporting.
+        Assert.That(diff.HasChanges, Is.False);
+    }
+
+    [Test]
+    public void Compare_OrdersChangesAsEnteredThenLeftThenBiggestMove()
+    {
+        var diff = TopDiffCalculator.Compare(
+            Snapshot(Yesterday, "a", "b", "c", "d", "e"),
+            Snapshot(Today, "z", "e", "a", "b", "c"));
+
+        // "z" entered, "d" left, then moves ordered by magnitude: e +3, a -2, b -2, c -2.
+        Assert.Multiple(() =>
+        {
+            Assert.That(diff.Changes[0].Kind, Is.EqualTo(ChangeKind.Entered));
+            Assert.That(diff.Changes[0].SpotifyId, Is.EqualTo("z"));
+            Assert.That(diff.Changes[1].Kind, Is.EqualTo(ChangeKind.Left));
+            Assert.That(diff.Changes[1].SpotifyId, Is.EqualTo("d"));
+            Assert.That(diff.Changes[2].SpotifyId, Is.EqualTo("e"));
+            Assert.That(Math.Abs(diff.Changes[2].Delta), Is.EqualTo(3));
+        });
+    }
+
+    [Test]
+    public void Summarize_CountsEachKindOfChange()
+    {
+        var diff = TopDiffCalculator.Compare(
+            Snapshot(Yesterday, "a", "b", "c"),
+            Snapshot(Today, "z", "a", "b"));
+
+        // "z" entered, "c" left, "a" and "b" each slipped one place.
+        Assert.That(diff.Summarize(), Is.EqualTo("Top artists: 1 new, 1 out, 2 moved"));
+    }
+
+    [Test]
+    public void Compare_WithDuplicateIdsInAList_DoesNotThrow()
+    {
+        var current = new TopSnapshot
+        {
+            CapturedAt = Today,
+            EntityType = TopEntityType.Artist,
+            TimeRange = "short",
+            Entries =
+            [
+                new TopEntry(1, "dup", "Artist", string.Empty),
+                new TopEntry(2, "dup", "Artist", string.Empty)
+            ]
+        };
+
+        Assert.DoesNotThrow(() => TopDiffCalculator.Compare(Snapshot(Yesterday, "dup"), current));
+    }
+
+    #endregion
+
+}


### PR DESCRIPTION
Snapshots the top 50 Spotify artists and tracks once a day, diffs each run against the previous one, and reports what moved via a Windows toast.

## Why a Scheduled Task, not a Windows Service

The original plan was a Windows Service modeled on the Gmailer sync worker. A service runs in Session 0 and **cannot deliver toast notifications** to the desktop, which is the whole point here. An interactive Scheduled Task can, needs no elevation to install, and resolves `%APPDATA%` to the real user so it can read the OAuth token the CLI already stores.

`scripts/install-monitor.ps1` keeps the same idempotent shape as the Gmailer install script — publish to staging, copy, then a Reinstall / Run now / Uninstall / Cancel prompt when it is already installed.

## Layout

`src/core/monitor/` holds everything testable without Spotify or Windows:

| | |
|---|---|
| `TopDiffCalculator` | Matches entries on Spotify **id**, not name, so a rename does not read as one entry leaving and another entering |
| `SqliteSnapshotStore` | `%APPDATA%\spoticli\history.db`, cascade delete, retention pruning |
| `TopMonitorService` | fetch → diff → persist |
| `MonitorReport` | Full text for the log, ranked highlights for the toast where only a few lines fit |

`src/monitor/` owns the Windows-specific parts. `ToastNotifier` calls WinRT directly rather than taking a NuGet dependency, and registers its own AUMID under `HKCU` — without that, Windows silently drops toasts from an unpackaged exe.

Persistence and notification were the two open design questions; SQLite and toast were chosen deliberately over a JSON log / MongoDB and over email.

## Behavior worth knowing

- **A run where nothing moved stays silent.** A daily "nothing happened" toast would only train you to ignore them. `--notify-always` overrides.
- **Default range is `short` (4 weeks)** — the only one that meaningfully moves day to day. `Monitor.TimeRanges` in `config.json` can track `medium` and `long` too.
- **Short-term top *artists* returns ~10, not 50.** That is Spotify: 4 weeks of listening does not span 50 distinct artists. Tracks do return a full 50. Not a bug, but it makes the artist report look thin.

## Verification

27 unit tests pass, and the exe was run against a live Spotify account:

- baseline run persisted, second run read it back and correctly reported "no change" with the toast suppressed
- forced a real change scenario, which produced correct text (`Lay Low - Tiësto is no longer in the top 8 (was #13)`) and raised a real toast. `W&W` appearing in output confirms the XML escaping holds
- log file is proper UTF-8

CI runs on `windows-latest`, so the `net10.0-windows10.0.19041.0` TFM on the new project is fine.

## Reviewer notes

- Pins `SQLitePCLRaw.bundle_e_sqlite3` above the version `Microsoft.Data.Sqlite` resolves, which carries GHSA-2m69-gcr7-jv3q.
- `TopCommand` now shares time-range parsing via `SpotifyTimeRange` so the CLI and monitor cannot drift apart. Only refactor to existing behavior in this PR.
- The monitor reads the refresh token but never writes a rotated one back. That matches existing CLI behavior, so it is not a regression — but if Spotify ever rotates the token, both would need a re-login.
- Email notification was scoped out. `INotifier` is the seam if it is wanted later; note `pm.me` needs Proton Mail Bridge for SMTP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
